### PR TITLE
Added executeLocal function to coreTasks

### DIFF
--- a/lib/coreTasks.js
+++ b/lib/coreTasks.js
@@ -1,8 +1,9 @@
-module.exports = function(hitler) {
-  hitler.registerTask('copy', copy);
-  hitler.registerTask('execute', execute);
-  hitler.registerTask('executeScript', executeScript);
-  hitler.registerTask('print', print);
+module.exports = function(nodemiral) {
+  nodemiral.registerTask('copy', copy);
+  nodemiral.registerTask('execute', execute);
+  nodemiral.registerTask('executeScript', executeScript);
+  nodemiral.registerTask('executeLocal', executeLocal);
+  nodemiral.registerTask('print', print);
 };
 
 function copy(session, options, callback, varsMapper) {
@@ -17,6 +18,10 @@ function execute(session, options, callback, varsMapper) {
   session.execute(options.command, sendCallback(callback, varsMapper));
 }
 
+function executeLocal(session, options, callback, varsMapper) {
+  session.executeLocal(options.command, options, sendCallback(callback, varsMapper));
+}
+
 function executeScript(session, options, callback, varsMapper) {
   session.executeScript(options.script, options.vars || {}, sendCallback(callback, varsMapper));
 }
@@ -27,11 +32,11 @@ function print(session, options, callback, varsMapper) {
 }
 
 function sendCallback(callback, varsMapper) {
-  return function(err, code, logs) {
+  return function(err, code, logs, returnValue) {
     if (err) {
       callback(err);
     } else if(code !== 0) {
-      
+
       var errorMessage = '\n-----------------------------------STDERR-----------------------------------\n';
       errorMessage += tail(logs.stderr);
       errorMessage += (errorMessage[errorMessage.length-1] != '\n')? '\n' : "";
@@ -45,7 +50,7 @@ function sendCallback(callback, varsMapper) {
       if(varsMapper) {
         varsMapper(applyTrim(logs.stdout), applyTrim(logs.stderr));
       }
-      callback();
+      callback(null, returnValue);
     }
   };
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var ejs = require('ejs');
 var path = require('path');
 var debug = require('debug');
+var sleep = require('sleep');
 
 function Session(host, auth, options) {
   if(!(this instanceof Session)) {
@@ -199,6 +200,32 @@ Session.prototype.execute = function(shellCommand, options, callback) {
   }
 };
 
+Session.prototype.executeLocal = function(command, options, callback) {
+  commandArguments = options.arguments || [];
+  commandOptions = options.options || {};
+  callback = callback || function() {};
+  var process;
+
+  var self = this;
+
+  function afterCompleted() {
+    var args = arguments;
+    callback.apply(self, args);
+  }
+
+  if (options.continueImmedidately) {
+    var sleepTime = options.sleepTime || 0;
+
+    process = self._doSpawnLocal(command, commandArguments, commandOptions, options);
+    sleep.sleep(sleepTime);
+
+    var logs = { stdout: "", stderr: ""};
+    callback(null, 0, logs, process);
+  }
+  else
+    self._doSpawn(command, commandOptions, afterCompleted);
+};
+
 Session.prototype.executeScript = function(scriptFile, vars, options, callback) {
   if(typeof(options) == 'function') {
     callback = options;
@@ -328,6 +355,90 @@ Session.prototype._doSpawn = function(command, options, callback) {
     });
     timeoutHandler = null;
   }
+};
+
+Session.prototype._doSpawnLocal = function(command, commandArguments, commandOptions, options, callback) {
+  var self = this;
+  var logs = { stdout: "", stderr: ""};
+  var timeoutHandler;
+  var spawned;
+
+  this._debug('spawning command- %s', command);
+
+  spawned = spawn(command, commandArguments, commandOptions);
+
+  spawned.stdout.on('data', onStdOut);
+  spawned.stderr.on('data', onStdErr);
+  spawned.once('error', sendCallback);
+  spawned.once('close', onClose);
+
+  if(options.onStdout) {
+    spawned.stdout.on('data', options.onStdout);
+  }
+
+  if(options.onStderr) {
+    spawned.stderr.on('data', options.onStderr);
+  }
+
+  if(self._timeout) {
+    timeoutHandler = setTimeout(onTimeout, self._timeout);
+  }
+
+  function sendCallback(err, code, logs) {
+    if(err) {
+      self._debug('error: %s', err.message);
+    } else {
+      self._debug('spawn completed - code: %d - \n\tstdout: %s \t\tstderr', code, logs.stdout, logs.stderr);
+    }
+
+    if(callback) {
+      callback(err, code, logs);
+      callback = null;
+
+      //cleanup
+      spawned.stdout.removeListener('data', onStdOut);
+      spawned.stderr.removeListener('data', onStdErr);
+
+      if(options.onStdout) {
+        spawned.stdout.removeListener('data', options.onStdout);
+      }
+      if(options.onStderr) {
+        spawned.stderr.removeListener('data', options.onStderr);
+      }
+
+      spawned.removeListener('error', sendCallback);
+      spawned.removeListener('close', onClose);
+    }
+  }
+
+  function onClose(code) {
+    if(timeoutHandler) {
+      clearTimeout(timeoutHandler);
+      timeoutHandler = null;
+    }
+    sendCallback(null, code, logs);
+  }
+
+  function onStdOut(data) {
+    logs.stdout += data.toString();
+  }
+
+  function onStdErr(data) {
+    logs.stderr += data.toString();
+  }
+
+  function onTimeout() {
+    var killScript = path.resolve(__dirname, '../scripts/kill.sh');
+    sendCallback(new Error('TIMEOUT'));
+    exec('sh ' + killScript + ' ' + spawned.pid, function(err) {
+      if(err) {
+        console.error('Killing on timeout failed');
+      }
+    });
+    timeoutHandler = null;
+  }
+
+  return spawned;
 };
 
 module.exports = Session;

--- a/lib/taskList.js
+++ b/lib/taskList.js
@@ -87,7 +87,7 @@ TaskList.prototype._runTaskQueue = function(session, callback) {
       self.emit('started', task.id);
       self.log('log', util.format('[%s] '.magenta+'- %s', session._host, task.id));
       var options = self._evaluateOptions(task.options, session);
-      TaskList._registeredTasks[task.type](session, options, function(err) {
+      TaskList._registeredTasks[task.type](session, options, function(err, returnValue) {
         if(err) {
           taskHistory.push({
             task: task.id,
@@ -109,6 +109,11 @@ TaskList.prototype._runTaskQueue = function(session, callback) {
           });
           self.log('log', util.format('[%s] '.magenta+'\u2714 %s: SUCCESS'.green, session._host, task.id));
           self.emit('success', task.id);
+
+          if (options.callback && typeof(options.callback) == 'function') {
+            options.callback(returnValue);
+          }
+
           runTask();
         }
       }, function(stdout, stderr) {
@@ -141,9 +146,11 @@ TaskList.prototype._evaluateOptions = function(options, session) {
     return options;
   } else if(typeof(options) == 'object') {
     for(var key in options) {
+
       var value = options[key];
 
-      if(typeof(value) == 'function') {
+      // do not evaluate onSuccess function -> this function is needed to return process on task success
+      if(typeof(value) == 'function' && if (key !== 'onSuccess')) {
         var vars = self._getVarsForSession(session);
         options[key] = value.call(vars, self._globalVars);
       } else if(value == null) {

--- a/lib/taskList.js
+++ b/lib/taskList.js
@@ -19,7 +19,7 @@ function TaskList(name, options) {
   this._vars = {};
 
   //used by all the tasks and sessions;
-  this._globalVars = {}; 
+  this._globalVars = {};
 
   this._dependingTasks = [];
 }
@@ -28,7 +28,7 @@ util.inherits(TaskList, EventEmitter);
 
 TaskList.prototype.run = function(sessions, options, callback) {
   var self = this;
-  
+
   if(!sessions) {
     throw new Error('First parameter should be either a session or a list of sessions');
   } else if(!(sessions instanceof Array)) {
@@ -78,7 +78,7 @@ TaskList.prototype._runTaskQueue = function(session, callback) {
   var self = this;
   var cnt = 0;
   var taskHistory = [];
-  
+
   runTask();
 
   function runTask() {
@@ -150,7 +150,7 @@ TaskList.prototype._evaluateOptions = function(options, session) {
       var value = options[key];
 
       // do not evaluate onSuccess function -> this function is needed to return process on task success
-      if(typeof(value) == 'function' && if (key !== 'onSuccess')) {
+      if(typeof(value) == 'function' && (key !== 'onSuccess')) {
         var vars = self._getVarsForSession(session);
         options[key] = value.call(vars, self._globalVars);
       } else if(value == null) {
@@ -193,7 +193,7 @@ TaskList.registerTask = function(name, callback) {
   TaskList._registeredTasks[name] = callback;
   TaskList.prototype[name] = function(id, options, varsMapper) {
     this._taskQueue.push({
-      type: name, 
+      type: name,
       id: id,
       options: options,
       varsMapper: varsMapper

--- a/lib/taskList.js
+++ b/lib/taskList.js
@@ -110,8 +110,8 @@ TaskList.prototype._runTaskQueue = function(session, callback) {
           self.log('log', util.format('[%s] '.magenta+'\u2714 %s: SUCCESS'.green, session._host, task.id));
           self.emit('success', task.id);
 
-          if (options.callback && typeof(options.callback) == 'function') {
-            options.callback(returnValue);
+          if (options.onSuccess && typeof(options.onSuccess) == 'function') {
+            options.onSuccess(returnValue);
           }
 
           runTask();


### PR DESCRIPTION
Hi there!

I've worked on a pull production database option for meteor-up (ump pulldb), which required to execute commands on the local machine with the benefits of adding it to an existing task list.

For the executeLocal function, one can also define an onSuccess function as option, which will be called on success and the spawned executing process as parameter. By this, a service can be started and kept alive until dependent tasks are finished. An example is below.

Would be glad if you could consider this or similar for a future release.

```javascript
var mongoDbProcess;

var mongoDbDir = app + "/.meteor/local/db";
var startMongoDbCmd = "mongod";
taskList.executeLocal("Starting local mongo database instance", {
  command: startMongoDbCmd,
  arguments: [
    "--bind_ip",
    "127.0.0.1",
    "--smallfiles",
    "--nohttpinterface",
    "--port",
    "3002",
    "--dbpath",
    "./"
  ],
  options: {
    cwd: mongoDbDir,
  },
  continueImmedidately: true,
  sleepTime: 1,
  onSuccess: function(value) {
    mongoDbProcess = value;
  }
});

var importDumpCmd = "mongorestore --db meteor -host 127.0.0.1 --port 3002 --drop opt/" + appName + "/tmp/dump/" + appName;
taskList.executeLocal("Importing dump", {
  command: importDumpCmd,
  onSuccess: function() {
    if (mongoDbProcess) {
      mongoDbProcess.kill();
    }
  }
});
```